### PR TITLE
Ignore case when adding / removing pokemon to the list

### DIFF
--- a/src/pokedex.js
+++ b/src/pokedex.js
@@ -11,7 +11,7 @@ exports.pokedex = pokedex;
 exports.getPokemonIdsByNames = function(names) {
     return names.map(function(name) {
         return _.findKey(pokedex, function(p) {
-            return p === name;
+            return p.toLowerCase() === name.toLowerCase();
         });
     }).filter(function(p) {
         return p !== undefined;


### PR DESCRIPTION
This PR makes Pokémon names case-insensitive when adding / removing to / from the watchlist.
